### PR TITLE
Add React TypeScript Planet Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "planetexplorer",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^4.9.3",
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^3.0.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Planet Explorer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,22 @@
+# Planet Explorer
+
+Planet Explorer is a simple React + TypeScript application that lists planets in our solar system and shows information about them. When selecting Mars it also fetches the latest weather report from a public API.
+
+## Development
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start the development server
+   ```bash
+   npm run dev
+   ```
+
+## Build
+
+```
+npm run build
+```
+
+The app fetches planets from [Solar System OpenData API](https://api.le-systeme-solaire.net/) and Mars weather data from [MAAS2](https://maas2.apollorion.com/).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import PlanetExplorer from './components/PlanetExplorer';
+
+const App: React.FC = () => {
+  return (
+    <div>
+      <h1>Planet Explorer</h1>
+      <PlanetExplorer />
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/PlanetExplorer.tsx
+++ b/src/components/PlanetExplorer.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { Planet, MarsWeather } from '../types';
+
+const PLANETS_URL = 'https://api.le-systeme-solaire.net/rest/bodies?filter%5BisPlanet%5D=1';
+const MARS_WEATHER_URL = 'https://api.maas2.apollorion.com/';
+
+const PlanetExplorer: React.FC = () => {
+  const [planets, setPlanets] = useState<Planet[]>([]);
+  const [selectedPlanet, setSelectedPlanet] = useState<Planet | null>(null);
+  const [marsWeather, setMarsWeather] = useState<MarsWeather | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetch(PLANETS_URL)
+      .then(res => res.json())
+      .then(data => setPlanets(data.bodies))
+      .catch(err => console.error(err));
+  }, []);
+
+  const selectPlanet = (planet: Planet) => {
+    setSelectedPlanet(planet);
+    if (planet.englishName.toLowerCase() === 'mars') {
+      setLoading(true);
+      fetch(MARS_WEATHER_URL)
+        .then(res => res.json())
+        .then(data => {
+          setMarsWeather(data); // data is the latest weather
+        })
+        .catch(err => console.error(err))
+        .finally(() => setLoading(false));
+    } else {
+      setMarsWeather(null);
+    }
+  };
+
+  return (
+    <div>
+      <ul>
+        {planets.map(p => (
+          <li key={p.id} onClick={() => selectPlanet(p)} style={{ cursor: 'pointer' }}>
+            {p.englishName}
+          </li>
+        ))}
+      </ul>
+      {selectedPlanet && (
+        <div>
+          <h2>{selectedPlanet.englishName}</h2>
+          <p>Gravity: {selectedPlanet.gravity} m/s²</p>
+          <p>Mean Radius: {selectedPlanet.meanRadius} km</p>
+          <p>Moons: {selectedPlanet.moons ? selectedPlanet.moons.length : 0}</p>
+          {selectedPlanet.englishName.toLowerCase() === 'mars' && (
+            <div>
+              <h3>Latest Mars Weather</h3>
+              {loading && <p>Loading weather...</p>}
+              {marsWeather && (
+                <div>
+                  <p>Sol: {marsWeather.sol}</p>
+                  <p>Date: {marsWeather.terrestrial_date}</p>
+                  <p>Min Temp: {marsWeather.min_temp} °C</p>
+                  <p>Max Temp: {marsWeather.max_temp} °C</p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PlanetExplorer;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+export interface Planet {
+  id: string;
+  englishName: string;
+  gravity: number;
+  meanRadius: number;
+  moons?: { moon: string }[];
+}
+
+export interface MarsWeather {
+  sol: string;
+  terrestrial_date: string;
+  min_temp: number;
+  max_temp: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- set up a minimal React + TypeScript project using Vite configuration
- implement `PlanetExplorer` component that lists solar system planets using the Solar System OpenData API
- fetch Mars weather from the MAAS2 API
- add development instructions in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68406b8add88832780cc9375378e1be3