### PR TITLE
Improve planet info UI with icons

### DIFF
--- a/src/assets/earth.svg
+++ b/src/assets/earth.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#2c74ff" />
+</svg>

--- a/src/assets/jupiter.svg
+++ b/src/assets/jupiter.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#d7b77a" />
+</svg>

--- a/src/assets/mars.svg
+++ b/src/assets/mars.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#d14b36" />
+</svg>

--- a/src/assets/mercury.svg
+++ b/src/assets/mercury.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#b1b1b1" />
+</svg>

--- a/src/assets/neptune.svg
+++ b/src/assets/neptune.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#4866b1" />
+</svg>

--- a/src/assets/saturn.svg
+++ b/src/assets/saturn.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#e4d18d" />
+</svg>

--- a/src/assets/uranus.svg
+++ b/src/assets/uranus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#7ad7e0" />
+</svg>

--- a/src/assets/venus.svg
+++ b/src/assets/venus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#eccc6b" />
+</svg>

--- a/src/components/PlanetExplorer.tsx
+++ b/src/components/PlanetExplorer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Planet, MarsWeather } from '../types';
+import { PLANET_ORDER, PLANET_IMAGES, PLANET_FACTS } from '../planetData';
 
 const PLANETS_URL = 'https://api.le-systeme-solaire.net/rest/bodies?filter%5BisPlanet%5D=1';
 const MARS_WEATHER_URL = 'https://api.maas2.apollorion.com/';
@@ -13,7 +14,12 @@ const PlanetExplorer: React.FC = () => {
   useEffect(() => {
     fetch(PLANETS_URL)
       .then(res => res.json())
-      .then(data => setPlanets(data.bodies))
+      .then(data => {
+        const ordered = PLANET_ORDER.map(name =>
+          data.bodies.find((b: Planet) => b.englishName === name)
+        ).filter(Boolean) as Planet[];
+        setPlanets(ordered);
+      })
       .catch(err => console.error(err));
   }, []);
 
@@ -37,7 +43,8 @@ const PlanetExplorer: React.FC = () => {
     <div>
       <ul>
         {planets.map(p => (
-          <li key={p.id} onClick={() => selectPlanet(p)} style={{ cursor: 'pointer' }}>
+          <li key={p.id} onClick={() => selectPlanet(p)} style={{ cursor: 'pointer', listStyle: 'none', marginBottom: '8px' }}>
+            <img src={PLANET_IMAGES[p.englishName]} alt={p.englishName} width={32} height={32} style={{ verticalAlign: 'middle', marginRight: '8px' }} />
             {p.englishName}
           </li>
         ))}
@@ -45,8 +52,11 @@ const PlanetExplorer: React.FC = () => {
       {selectedPlanet && (
         <div>
           <h2>{selectedPlanet.englishName}</h2>
+          <img src={PLANET_IMAGES[selectedPlanet.englishName]} alt={selectedPlanet.englishName} width={200} height={200} />
+          <p>{PLANET_FACTS[selectedPlanet.englishName]}</p>
           <p>Gravity: {selectedPlanet.gravity} m/s²</p>
           <p>Mean Radius: {selectedPlanet.meanRadius} km</p>
+          <p>Distance from Sun: {selectedPlanet.semimajorAxis} km</p>
           <p>Moons: {selectedPlanet.moons ? selectedPlanet.moons.length : 0}</p>
           {selectedPlanet.englishName.toLowerCase() === 'mars' && (
             <div>

--- a/src/planetData.ts
+++ b/src/planetData.ts
@@ -1,0 +1,41 @@
+import MercuryImg from './assets/mercury.svg';
+import VenusImg from './assets/venus.svg';
+import EarthImg from './assets/earth.svg';
+import MarsImg from './assets/mars.svg';
+import JupiterImg from './assets/jupiter.svg';
+import SaturnImg from './assets/saturn.svg';
+import UranusImg from './assets/uranus.svg';
+import NeptuneImg from './assets/neptune.svg';
+
+export const PLANET_ORDER = [
+  'Mercury',
+  'Venus',
+  'Earth',
+  'Mars',
+  'Jupiter',
+  'Saturn',
+  'Uranus',
+  'Neptune',
+] as const;
+
+export const PLANET_IMAGES: Record<string, string> = {
+  Mercury: MercuryImg,
+  Venus: VenusImg,
+  Earth: EarthImg,
+  Mars: MarsImg,
+  Jupiter: JupiterImg,
+  Saturn: SaturnImg,
+  Uranus: UranusImg,
+  Neptune: NeptuneImg,
+};
+
+export const PLANET_FACTS: Record<string, string> = {
+  Mercury: 'Mercury is the smallest planet and closest to the Sun.',
+  Venus: 'Venus has a thick, toxic atmosphere that traps heat.',
+  Earth: 'Earth is the only planet known to support life.',
+  Mars: 'Mars is often called the Red Planet.',
+  Jupiter: 'Jupiter is the largest planet in our solar system.',
+  Saturn: 'Saturn is known for its prominent ring system.',
+  Uranus: 'Uranus rotates on its side relative to its orbit.',
+  Neptune: 'Neptune is the most distant planet from the Sun.',
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface Planet {
   englishName: string;
   gravity: number;
   meanRadius: number;
+  semimajorAxis: number;
   moons?: { moon: string }[];
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*.svg' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- add SVG planet icons and simple facts
- display facts and icons for each planet in PlanetExplorer
- order planets by distance from the Sun
- type definitions for svg modules and semimajorAxis field

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68406ebb903483279c85b1c88fbc887d