### PR TITLE
Improve planet explorer with dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Planet Explorer is a simple React + TypeScript application that lists planets in
 npm run build
 ```
 
-The app fetches planets from [Solar System OpenData API](https://api.le-systeme-solaire.net/) and Mars weather data from [MAAS2](https://maas2.apollorion.com/).
+The app fetches planets from [Solar System OpenData API](https://api.le-systeme-solaire.net/) and Mars weather data from NASA's [MSL Weather Service](https://mars.nasa.gov/rss/api/?feed=weather&category=msl&feedtype=json).

--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planet Explorer</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/src/index.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,21 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PlanetExplorer from './components/PlanetExplorer';
 
 const App: React.FC = () => {
+  const [dark, setDark] = useState(true);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+
   return (
     <div>
-      <h1>Planet Explorer</h1>
+      <header className="app-header">
+        <h1>Planet Explorer</h1>
+        <button className="theme-toggle" onClick={() => setDark(d => !d)}>
+          Toggle Theme
+        </button>
+      </header>
       <PlanetExplorer />
     </div>
   );

--- a/src/assets/earth.svg
+++ b/src/assets/earth.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#2c74ff" />
+</svg>

--- a/src/assets/jupiter.svg
+++ b/src/assets/jupiter.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#d7b77a" />
+</svg>

--- a/src/assets/mars.svg
+++ b/src/assets/mars.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#d14b36" />
+</svg>

--- a/src/assets/mercury.svg
+++ b/src/assets/mercury.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#b1b1b1" />
+</svg>

--- a/src/assets/neptune.svg
+++ b/src/assets/neptune.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#4866b1" />
+</svg>

--- a/src/assets/saturn.svg
+++ b/src/assets/saturn.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#e4d18d" />
+</svg>

--- a/src/assets/uranus.svg
+++ b/src/assets/uranus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#7ad7e0" />
+</svg>

--- a/src/assets/venus.svg
+++ b/src/assets/venus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#eccc6b" />
+</svg>

--- a/src/components/PlanetExplorer.tsx
+++ b/src/components/PlanetExplorer.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Planet, MarsWeather } from '../types';
+import { PLANET_ORDER, PLANET_IMAGES, PLANET_FACTS } from '../planetData';
 
 const PLANETS_URL = 'https://api.le-systeme-solaire.net/rest/bodies?filter%5BisPlanet%5D=1';
-const MARS_WEATHER_URL = 'https://api.maas2.apollorion.com/';
+const MARS_WEATHER_URL =
+  'https://mars.nasa.gov/rss/api/?feed=weather&category=msl&feedtype=json';
 
 const PlanetExplorer: React.FC = () => {
   const [planets, setPlanets] = useState<Planet[]>([]);
@@ -13,7 +15,12 @@ const PlanetExplorer: React.FC = () => {
   useEffect(() => {
     fetch(PLANETS_URL)
       .then(res => res.json())
-      .then(data => setPlanets(data.bodies))
+      .then(data => {
+        const ordered = PLANET_ORDER.map(name =>
+          data.bodies.find((b: Planet) => b.englishName === name)
+        ).filter(Boolean) as Planet[];
+        setPlanets(ordered);
+      })
       .catch(err => console.error(err));
   }, []);
 
@@ -24,7 +31,25 @@ const PlanetExplorer: React.FC = () => {
       fetch(MARS_WEATHER_URL)
         .then(res => res.json())
         .then(data => {
-          setMarsWeather(data); // data is the latest weather
+          // API returns an array of sols under `soles` or a `sol_keys` map
+          let latest: any = null;
+          if (Array.isArray(data.soles)) {
+            latest = data.soles[0];
+          } else if (Array.isArray(data.sol_keys) && data.sol_keys.length > 0) {
+            const key = data.sol_keys[0];
+            latest = { sol: key, ...data[key] };
+          }
+          if (latest) {
+            setMarsWeather({
+              sol: String(latest.sol),
+              terrestrial_date:
+                latest.terrestrial_date || latest.First_UTC || '',
+              min_temp: latest.min_temp ?? latest.AT?.mn ?? 0,
+              max_temp: latest.max_temp ?? latest.AT?.mx ?? 0,
+            });
+          } else {
+            setMarsWeather(null);
+          }
         })
         .catch(err => console.error(err))
         .finally(() => setLoading(false));
@@ -35,18 +60,29 @@ const PlanetExplorer: React.FC = () => {
 
   return (
     <div>
-      <ul>
+      <ul className="planet-list">
         {planets.map(p => (
-          <li key={p.id} onClick={() => selectPlanet(p)} style={{ cursor: 'pointer' }}>
+          <li
+            key={p.id}
+            className={`planet-item ${selectedPlanet?.id === p.id ? 'selected' : ''}`}
+            onClick={() => selectPlanet(p)}
+          >
+            <img src={PLANET_IMAGES[p.englishName]} alt={p.englishName} />
             {p.englishName}
           </li>
         ))}
       </ul>
       {selectedPlanet && (
-        <div>
+        <div className="planet-details">
           <h2>{selectedPlanet.englishName}</h2>
+          <img
+            src={PLANET_IMAGES[selectedPlanet.englishName]}
+            alt={selectedPlanet.englishName}
+          />
+          <p>{PLANET_FACTS[selectedPlanet.englishName]}</p>
           <p>Gravity: {selectedPlanet.gravity} m/s²</p>
           <p>Mean Radius: {selectedPlanet.meanRadius} km</p>
+          <p>Distance from Sun: {selectedPlanet.semimajorAxis} km</p>
           <p>Moons: {selectedPlanet.moons ? selectedPlanet.moons.length : 0}</p>
           {selectedPlanet.englishName.toLowerCase() === 'mars' && (
             <div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,92 @@
+:root {
+  --bg-color: #f8f8f8;
+  --text-color: #111;
+  --card-bg: #fff;
+  --accent-color: #ff0066;
+}
+
+[data-theme='dark'] {
+  --bg-color: radial-gradient(circle at 20% 20%, #232323, #000);
+  --text-color: #e8e8e8;
+  --card-bg: #1e1e1e;
+  --accent-color: #ff0066;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-family: 'Orbitron', Arial, Helvetica, sans-serif;
+  transition: background 0.3s, color 0.3s;
+  min-height: 100vh;
+}
+
+.app-header {
+  text-align: center;
+  padding: 1rem;
+}
+
+.theme-toggle {
+  margin-left: 1rem;
+  padding: 0.3rem 0.6rem;
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.planet-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 0;
+  gap: 1rem;
+}
+
+.planet-item {
+  list-style: none;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  background: var(--card-bg);
+  transition: transform 0.2s, background 0.3s;
+  text-align: center;
+  width: 90px;
+}
+
+.planet-item:hover {
+  transform: translateY(-4px);
+  background: var(--accent-color);
+  color: #fff;
+}
+
+.planet-item.selected {
+  background: var(--accent-color);
+  color: #fff;
+}
+
+.planet-item img {
+  width: 48px;
+  height: 48px;
+  display: block;
+  margin: 0 auto 4px;
+}
+
+.planet-details {
+  background: var(--card-bg);
+  padding: 1rem;
+  border-radius: 10px;
+  margin-top: 2rem;
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+.planet-details img {
+  width: 150px;
+  height: 150px;
+  display: block;
+  margin: 0 auto 1rem;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/planetData.ts
+++ b/src/planetData.ts
@@ -1,0 +1,41 @@
+import MercuryImg from './assets/mercury.svg';
+import VenusImg from './assets/venus.svg';
+import EarthImg from './assets/earth.svg';
+import MarsImg from './assets/mars.svg';
+import JupiterImg from './assets/jupiter.svg';
+import SaturnImg from './assets/saturn.svg';
+import UranusImg from './assets/uranus.svg';
+import NeptuneImg from './assets/neptune.svg';
+
+export const PLANET_ORDER = [
+  'Mercury',
+  'Venus',
+  'Earth',
+  'Mars',
+  'Jupiter',
+  'Saturn',
+  'Uranus',
+  'Neptune',
+] as const;
+
+export const PLANET_IMAGES: Record<string, string> = {
+  Mercury: MercuryImg,
+  Venus: VenusImg,
+  Earth: EarthImg,
+  Mars: MarsImg,
+  Jupiter: JupiterImg,
+  Saturn: SaturnImg,
+  Uranus: UranusImg,
+  Neptune: NeptuneImg,
+};
+
+export const PLANET_FACTS: Record<string, string> = {
+  Mercury: 'Mercury is the smallest planet and closest to the Sun.',
+  Venus: 'Venus has a thick, toxic atmosphere that traps heat.',
+  Earth: 'Earth is the only planet known to support life.',
+  Mars: 'Mars is often called the Red Planet.',
+  Jupiter: 'Jupiter is the largest planet in our solar system.',
+  Saturn: 'Saturn is known for its prominent ring system.',
+  Uranus: 'Uranus rotates on its side relative to its orbit.',
+  Neptune: 'Neptune is the most distant planet from the Sun.',
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface Planet {
   englishName: string;
   gravity: number;
   meanRadius: number;
+  semimajorAxis: number;
   moons?: { moon: string }[];
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*.svg' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- include orbitron font and global styles
- allow theme toggling between light and dark
- style planet list and details with accent color

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68406ebb903483279c85b1c88fbc887d